### PR TITLE
docs: Align documentation with Project Zomboid MCP Server PRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - YYYY-MM-DD
 
+**Foundation - Data Extraction Pipeline (Initial Implementation)**
+
+This initial version focuses on parsing and structuring Project Zomboid script data.
+
 ### Added
 
-*   Initial MCP server prototype:
-    *   Script parser for items, recipes, vehicles, models, and templates.
-    *   Data models for structured representation of game entities.
-    *   Data transformer to map parsed data to models.
-    *   Data repository for loading and accessing game data.
-    *   Command-Line Interface (CLI) for interacting with the data.
-*   Comprehensive logging using Python's `logging` module across all components.
-*   Error handling for file operations, parsing issues, and data lookup.
-*   Namespacing for items based on their module definitions.
-*   Basic test harnesses within each module for core functionality verification.
+*   **Project Zomboid Script Parser:**
+    *   Parses items, recipes, vehicles, vehicle models, and script module definitions.
+    *   Handles nested structures, various value types, and comments.
+*   **Data Modeling:**
+    *   Python classes for `Item`, `Recipe`, `Vehicle`, etc., providing a structured representation of game entities.
+*   **Data Transformation:**
+    *   Logic to convert raw parsed data into instances of the defined data models.
+*   **Data Repository (`GameDataRepository`):**
+    *   Loads all Project Zomboid script files from a specified directory.
+    *   Manages parsed and transformed game data objects.
+    *   Provides methods to query data (e.g., get item by name, list all recipes).
+    *   Includes namespacing for items based on their script module.
+*   **Basic Command-Line Interface (`mcp_server_cli.py`):**
+    *   Allows direct interaction for inspecting loaded game data.
+*   **Logging Framework:**
+    *   Integrated Python's `logging` module across components for diagnostics and error reporting.
+*   **Error Handling:**
+    *   Graceful handling of file I/O errors, script parsing errors, and data lookup issues.
+*   **Initial Test Harnesses:**
+    *   Basic test setups within each major module to verify core functionality.
 
 ### Changed
 
-*   Optimized CLI list commands (`listitems`, `listrecipes`, `listvehicles`) to prevent redundant data fetching calls.
+*   Optimized CLI list commands (`listitems`, `listrecipes`, `listvehicles`) to prevent redundant data fetching.
 
 ### Fixed
 
-*   Ensured all warning messages, specifically in `data_models.py`, use the standard logging system instead of `print()`.
+*   Ensured all warning messages utilize the standard logging system (e.g., `logger.warning()` instead of `print()`).

--- a/README.md
+++ b/README.md
@@ -1,29 +1,45 @@
-# MCP Server Prototype
+# Project Zomboid MCP Server Prototype
 
 ## Overview
 
-The MCP (Master Control Program) Server Prototype is a Python-based application designed to parse, manage, and provide access to game data defined in text-based script files. These script files typically define game entities such as items, recipes, vehicles, and more, using a custom C-like or JSON-like syntax.
+The Project Zomboid MCP (Model Context Protocol) Server Prototype is a Python-based application aimed at transforming Project Zomboid mod development. It achieves this by providing intelligent script validation, generation, and contextual assistance, primarily designed to be leveraged by AI-enhanced tooling and direct modder use.
 
-The primary goal of this prototype is to establish a robust foundation for reading and interpreting these script files, making the data available for use by other game components or tools.
+This server parses and manages game data from Project Zomboid's script files (defining items, recipes, vehicles, etc.), making this data accessible and queryable. The long-term vision is to expose this information via the Model Context Protocol, enabling powerful integrations with AI assistants like Claude and other development tools.
 
-## Components
+## Core Goals (from PRD)
 
-The server is comprised of several key Python modules:
+*   **Reduce Syntax Errors**: Validate scripts in real-time.
+*   **Accelerate Development**: Generate script templates.
+*   **Enhance Discovery**: Make vanilla game data searchable.
+*   **Improve AI Assistance**: Provide accurate, context-aware modding help.
 
-*   **`script_parser.py`**: Contains the lexer and parser responsible for reading the raw script files and converting them into a structured dictionary format. It handles syntax, comments, and various data structures within the scripts.
-*   **`data_models.py`**: Defines Python classes (e.g., `Item`, `Recipe`, `Vehicle`) that represent the game entities. These models use type hints and provide a clear, object-oriented way to work with the data.
-*   **`data_transformer.py`**: Bridges the gap between the parser's dictionary output and the data models. It transforms the raw parsed data into instances of the defined data model classes.
-*   **`data_repository.py`**: Acts as a central store for all loaded game data. It orchestrates the file reading, parsing, and transformation process. It then provides an API to query the loaded data (e.g., fetch an item by its name, list all available recipes).
-*   **`mcp_server_cli.py`**: A command-line interface (CLI) that allows users to interact with the loaded game data. It uses the `GameDataRepository` to fetch and display information.
+## Current Components
 
-## CLI Usage
+The prototype currently includes the following foundational Python modules:
 
-The primary way to interact with the MCP Server Prototype is through `mcp_server_cli.py`.
+*   **`script_parser.py`**: Lexer and parser for Project Zomboid script files, converting them into a structured dictionary format.
+*   **`data_models.py`**: Python classes representing game entities (Items, Recipes, Vehicles, etc.).
+*   **`data_transformer.py`**: Converts the parser's output into instances of the data models.
+*   **`data_repository.py`**: Loads, manages, and provides query access to all parsed game data from a specified Project Zomboid script directory.
+*   **`mcp_server_cli.py`**: A basic command-line interface (CLI) for direct interaction with the `GameDataRepository` to inspect loaded data.
 
-**Basic Syntax:**
+## Planned MCP Tools & Server Functionality
+
+While the current CLI allows for data inspection, the full vision includes developing a server (likely using FastAPI and the official `mcp` Python SDK) that will expose capabilities such as:
+
+*   **`validate_script`**: For real-time syntax and reference checking.
+*   **`generate_script`**: For creating new script files from templates.
+*   **`search_vanilla`**: For in-depth searching of vanilla game data.
+*   And other tools as outlined in the project's PRD.
+
+## Basic CLI Usage (Current)
+
+The CLI provides direct access to the data parsed by the current system.
+
+**Syntax:**
 
 ```bash
-python mcp_server_cli.py <path_to_script_directory> <command> [command_arguments]
+python mcp_server_cli.py <path_to_pz_script_directory> <command> [command_arguments]
 ```
 
 **Examples:**
@@ -38,33 +54,19 @@ python mcp_server_cli.py <path_to_script_directory> <command> [command_arguments
     python mcp_server_cli.py ./media/scripts getitem Base.Apple
     ```
 
-*   List all loaded recipes:
-    ```bash
-    python mcp_server_cli.py ./media/scripts listrecipes
-    ```
-
-*   Get details for a specific recipe:
-    ```bash
-    python mcp_server_cli.py ./media/scripts getrecipe MyRecipeName
-    ```
-
 ## Script File Format
 
-The script files generally use a C-like or JSON-like syntax. They consist of blocks defining modules, items, recipes, vehicles, etc., with properties specified as key-value pairs.
+Project Zomboid script files generally use a C-like or JSON-like syntax, defining modules, items, recipes, etc., with properties specified as key-value pairs. The parser is designed to handle this format.
 
-Example snippet:
-
+Example:
 ```
-module MyModule
+module Base
 {
-    item MyItem
+    item Apple
     {
-        DisplayName = "My Awesome Item",
-        Type = Normal,
-        Weight = 1.0,
-        Icon = MyItemIcon
+        Type = Food,
+        DisplayName = Apple,
+        Weight = 0.1
     }
 }
 ```
-
-The parser is designed to be relatively flexible with this format.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,49 +1,77 @@
-# Roadmap
+# Roadmap for Project Zomboid MCP Server
 
-This document outlines potential future directions and enhancements for the MCP Server Prototype. These are ideas for improvement and are not yet committed development tasks.
+This roadmap is derived from the project's PRD and outlines the planned development phases and features for the Project Zomboid MCP (Model Context Protocol) Server.
 
-## Short to Medium Term
+## Overall Vision
+To transform Project Zomboid mod development by providing intelligent script validation, generation, and contextual assistance through AI-enhanced tooling, primarily leveraging the Model Context Protocol.
+
+## Technical Stack Highlights (from PRD)
+*   **Core Language:** Python 3.11+
+*   **MCP Server Framework:** FastAPI
+*   **Database:** SQLite (with FTS5 for search)
+*   **Parser:** Custom Recursive Descent Parser (already developed in prototype)
+*   **Key Dependencies:** Official `mcp` Python SDK, `pydantic`
+
+## Development Phases
+
+### Phase 1: Foundation (Current Focus: Completing Remaining Items)
+
+*   **Data Extraction Pipeline (Partially Complete):**
+    *   ✅ Script parser for items, recipes, vehicles, etc. (Implemented)
+    *   ✅ Property extractor with basic type handling. (Implemented)
+    *   ✅ In-memory data models and repository. (Implemented)
+    *   **Next:** Implement SQLite database schema and populate with parsed vanilla game data.
+    *   **Next:** Enhance reference collection (sounds, sprites, items) during parsing.
+    *   **Next:** Refine handling of script syntax variations (e.g., `=` vs `:`) if further per-type strictness is needed.
+*   **Basic Validation Engine:**
+    *   **Next:** Develop line-by-line syntax validation for different script types.
+    *   **Next:** Implement property name verification against known valid properties per script type.
+    *   **Next:** Add value type and range checking.
+    *   **Next:** Implement basic error reporting with line numbers for validation failures.
+
+### Phase 2: Core MCP Tools & Server Implementation
+
+*   **MCP Server Backend:**
+    *   **Next:** Set up FastAPI application structure.
+    *   **Next:** Integrate the official `mcp` Python SDK.
+    *   **Next:** Design and implement MCP resources to expose game data (e.g., `vanilla_database`, `property_reference`).
+*   **`validate_script` Tool:**
+    *   Expose the Validation Engine's capabilities through an MCP tool.
+    *   Input: Script content, script type.
+    *   Output: Validation results with specific error locations.
+*   **`generate_script` Tool:**
+    *   Develop a template engine for generating script files.
+    *   Input: Script type, base template, custom properties.
+    *   Output: Formatted script with module wrapper.
+*   **`search_vanilla` Tool & Advanced Search:**
+    *   Implement SQLite FTS5 for full-text search on the vanilla data.
+    *   Develop property-based filtering and similarity matching.
+    *   Expose search capabilities via an MCP tool.
+*   **Additional MCP Resources:**
+    *   `property_reference`: Expose valid properties per script type.
+    *   `modding_templates`: Provide pre-built script templates.
+
+### Phase 3: Advanced Features
+
+*   **Contextual Intelligence:**
+    *   Property suggestions based on item type.
+    *   Common pattern recognition in scripts.
+    *   Compatibility warnings (e.g., for different game versions).
+*   **Mod Project Management Tools (via MCP):**
+    *   `analyze_mod`: File structure validation, cross-file reference tracking for a given mod directory.
+    *   Dependency management insights.
+    *   Build 42+ compatibility checking assistance.
+*   **`best_practices` MCP Resource:**
+    *   Expose modding guidelines and common patterns as a searchable resource.
+
+### Phase 4: Polish, Integration & Testing
 
 *   **Formal Testing Suite:**
-    *   Implement a comprehensive suite of unit and integration tests using a framework like `pytest` or `unittest`.
-    *   This will improve code reliability and make refactoring safer.
-
-*   **Advanced Data Queries:**
-    *   Extend `GameDataRepository` with more sophisticated query methods:
-        *   Find items by tags or other specific properties.
-        *   Filter recipes by required skills, ingredients, or tools.
-        *   Search for vehicles based on performance characteristics or parts.
-
-*   **Script Schema Validation:**
-    *   Implement a system for validating the structure and data types of parsed script files against a defined schema.
-    *   This would help catch errors in script files more proactively.
-
-*   **Enhanced CLI Features:**
-    *   Add more interactive elements or more complex query options to the CLI.
-    *   Support for outputting data in different formats (e.g., JSON, CSV).
-
-## Medium to Long Term
-
-*   **Web API Interface:**
-    *   Develop a web API (e.g., using Flask or FastAPI) to expose the game data.
-    *   This would allow other applications (e.g., game clients, web-based tools) to consume the data programmatically over HTTP.
-
-*   **Performance Enhancements:**
-    *   Profile the application with very large sets of script files.
-    *   Optimize parsing, data storage, and querying for better performance and memory usage if bottlenecks are identified.
-
-*   **Plugin System / Extensibility:**
-    *   Design a plugin system to allow for:
-        *   Support for new or custom script types without modifying the core parser.
-        *   Custom data transformation or validation rules.
-
-*   **Documentation Generation from Scripts:**
-    *   Create tools that can parse the game scripts and automatically generate human-readable documentation (e.g., item lists, recipe books) in formats like HTML or Markdown.
-
-*   **Configuration Management:**
-    *   Allow for more flexible configuration of the server (e.g., script paths, logging levels, feature flags) through a configuration file.
-
-## Community and Contributions
-
-*   Establish contribution guidelines if the project were to be open-sourced.
-*   Set up issue tracking and a process for community feedback.
+    *   Develop comprehensive unit and integration tests (e.g., using `pytest`).
+*   **Performance Optimization:**
+    *   Profile and optimize server performance, especially database queries and parsing for large mods.
+*   **Documentation:**
+    *   Finalize user and developer documentation.
+    *   Create examples and tutorials.
+*   **Claude Desktop Integration:**
+    *   Work towards seamless integration with Claude Desktop and other MCP clients.


### PR DESCRIPTION
I've revised README.md, CHANGELOG.md, and ROADMAP.md to accurately reflect the project's specific focus on Project Zomboid mod development, as detailed in the Product Requirements Document (PRD).

- README.md: I updated the project title, overview, and goals to emphasize Project Zomboid context and planned MCP server tools.
- CHANGELOG.md: I reframed version 0.1.0 to represent the initial implementation of the "Data Extraction Pipeline" for Project Zomboid scripts.
- ROADMAP.md: I replaced the previous generic roadmap with a detailed, phased development plan based on the PRD, including specific tools, features, and technical stack (FastAPI, SQLite, mcp SDK).